### PR TITLE
Support for all Angular versions since 6.0.0

### DIFF
--- a/projects/ngx-configure/package.json
+++ b/projects/ngx-configure/package.json
@@ -11,6 +11,7 @@
     "angular 6",
     "angular 7",
     "angular 8",
+    "angular 9",
     "json"
   ],
   "author": "Catriel Müller",
@@ -25,7 +26,7 @@
   },
   "version": "8.0.0",
   "peerDependencies": {
-    "@angular/common": "^8.1.0",
-    "@angular/core": "^8.1.0"
+    "@angular/common": ">6.0.0",
+    "@angular/core": ">6.0.0"
   }
 }

--- a/projects/ngx-configure/src/lib/ngx-configure.module.ts
+++ b/projects/ngx-configure/src/lib/ngx-configure.module.ts
@@ -21,7 +21,7 @@ import { NgxConfigureOptions } from './ngx-configure-options';
   ]
 })
 export class NgxConfigureModule {
-  public static forRoot(): ModuleWithProviders {
+  public static forRoot(): ModuleWithProviders<NgxConfigureModule> {
     return {
       ngModule: NgxConfigureModule,
       providers: [NgxConfigureService, NgxConfigureOptions]


### PR DESCRIPTION
Make ngx-configure available for Angular 6+
Use the generic variant of ModuleWithProviders (https://angular.io/guide/migration-module-with-providers)

Linked with issue #13 